### PR TITLE
feat: use bash:latest instead of ubuntu:latest

### DIFF
--- a/dvc.sh
+++ b/dvc.sh
@@ -50,7 +50,7 @@ if [[ "$?" -eq 0 ]]; then
 fi
 
 # most important part, data migration
-docker run --rm --volume ${OLD_VOLUME_NAME}:/source --volume ${NEW_VOLUME_NAME}:/destination ubuntu:latest bash -c "echo 'copying volume ...'; cp -R /source/* /destination/"
+docker run --rm --volume ${OLD_VOLUME_NAME}:/source --volume ${NEW_VOLUME_NAME}:/destination bash:latest bash -c "echo 'copying volume ...'; cp -R /source/* /destination/"
 
 if [[ "$?" -eq 0 ]]; then
     echo "Done successfuly 🎉"


### PR DESCRIPTION
While ubuntu:latest is already quite small an image (~25MB) it's still a bit overkill for a simple echo and copy action. bash:latest is only ~5MB in size and accomplishes the same thing.